### PR TITLE
build/linux: Update poppler module to 25.10

### DIFF
--- a/build/linux/flatpak/org.gimp.GIMP-nightly.json
+++ b/build/linux/flatpak/org.gimp.GIMP-nightly.json
@@ -245,8 +245,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://poppler.freedesktop.org/poppler-25.09.1.tar.xz",
-                    "sha256": "0c1091d01d3dd1664a13816861e812d02b29201e96665454b81b52d261fad658",
+                    "url": "https://poppler.freedesktop.org/poppler-25.10.0.tar.xz",
+                    "sha256": "6b5e9bb64dabb15787a14db1675291c7afaf9387438cc93a4fb7f6aec4ee6fe0",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 3686,


### PR DESCRIPTION
Synced from
https://github.com/flathub/org.gimp.GIMP/commit/6d4124f7b84be57a1a893e80d0018a6beffc6168